### PR TITLE
Fix validation for InternalPath and non-markdown identifiers

### DIFF
--- a/specifications/SpecificationsRequirements.md
+++ b/specifications/SpecificationsRequirements.md
@@ -763,13 +763,16 @@ Every **element** in the system has unique identifier that depends on document i
 ## Identifier in markdown document can be of several types
 
 -**Identifier**
-  - An internal system element reference represented as a string identifier.
-  - **Example**: `"some-identifier"`
+  - An internal system element reference with fragment, pointing to specific elements within markdown documents.
+  - Used for element-to-element relations (e.g., `derivedFrom`, `verifiedBy`, `verify`)
+  - **Example**: `"file.md#element-name"`
 - **ExternalUrl**
   - An external URL represented as a string.
+  - Used for references to external resources
   - **Example**: `"https://example.com"`
 - **InternalPath**
-  - An internal filesystem file path
+  - An internal filesystem file path without fragment, pointing to implementation files.
+  - Used for satisfaction and traceability relations (e.g., `satisfiedBy`, `satisfy`, `trace`)
   - **Example**: `"../core/src/diagrams.rs"`
   
   
@@ -1021,13 +1024,16 @@ Identifiers are used in relations to reference files or specific elements within
    ```
    
 
-## Valiation rules (TODO: add mising rules)
+## Validation rules
 
 The system must validate relation usage according to these rules:
 - Only the relation types defined in this registry are allowed
-- Relations should connect elements of appropriate types (TODO: append spec with rules).
+- Relations should connect elements of appropriate types
 - Circular dependencies should be detected and reported
-- Duplicate relation entries of same type and target are not allowed.
+- Duplicate relation entries of same type and target are not allowed
+- **Identifier** targets (with fragments) must reference existing elements in markdown documents
+- **InternalPath** targets (without fragments) must reference existing files in the filesystem
+- **ExternalUrl** targets are not validated for existence
       
 
 </details>

--- a/specifications/SystemRequirements/Requirements.md
+++ b/specifications/SystemRequirements/Requirements.md
@@ -1009,15 +1009,16 @@ The system shall implement validation that verifies relation endpoints have appr
 
 #### Details
 - For `verifiedBy`/`verify` relations, validate that one endpoint is a requirement element and the other is a verification element
-- For `satisfiedBy`/`satisfy` relations, validate that one endpoint is a requirement element and the other is an implementation element
+- For `satisfiedBy`/`satisfy` relations, validate that one endpoint is a requirement or verification element and the other is an implementation element
 - Relations should only connect elements of appropriate types based on the RelationTypesRegistry definition
 - Warnings should be issued when relation endpoints have incompatible element types
 
 #### Relations
   * derivedFrom: [../UserRequirements.md#Validate Relation Types](../UserRequirements.md#validate-relation-types)
-  * derivedFrom: [../SpecificationsRequirements.md#Relation Types And Behaviors](../SpecificationsRequirements.md#relation-types-and-behaviors)  
-  * satisfiedBy: [model.rs](../../core/src/model.rs)    
+  * derivedFrom: [../SpecificationsRequirements.md#Relation Types And Behaviors](../SpecificationsRequirements.md#relation-types-and-behaviors)
+  * satisfiedBy: [model.rs](../../core/src/model.rs)
   * satisfiedBy: [parser.rs](../../core/src/parser.rs)
+  * verifiedBy: [../../specifications/Verifications/ValidationTests.md#Invalid Relations Test](../../specifications/Verifications/ValidationTests.md#invalid-relations-test)
 
 ---
 

--- a/specifications/Verifications/ValidationTests.md
+++ b/specifications/Verifications/ValidationTests.md
@@ -107,6 +107,13 @@ The verification test checks that Reqvire correctly identifies and reports inval
 ##### Acceptance Criteria
 - System should detect and report invalid relation types (typos, etc.)
 - System should detect and report relations to non-existent targets
+- System should detect and report requirement elements with satisfiedBy relations pointing to non-existing local files
+- System should detect and report verification elements with satisfiedBy relations pointing to non-existing local files
+- System should detect and report requirement elements with verifiedBy relations pointing to non-existing verification elements
+- System should allow requirement elements with satisfiedBy relations pointing to existing implementation files
+- System should allow verification elements with satisfiedBy relations pointing to existing test scripts
+- System should detect and report requirement elements with satisfiedBy relations pointing to other requirement elements (incompatible types)
+- System should detect and report verification elements with satisfiedBy relations pointing to other verification elements (incompatible types)
 - System should detect and report if system requirement is missing parent relation
 - System should detect and report if there is circular dependency in requirements
 - System should detect and report if relation type has incompatible element

--- a/tests/test-fragment-relations/specifications/SystemRequirements/Requirements.md
+++ b/tests/test-fragment-relations/specifications/SystemRequirements/Requirements.md
@@ -10,7 +10,7 @@ The notification system must be designed with reliability and fault tolerance in
 
 
 #### Relations
-  * refine: [Reliable Requirements](#reliability-requirements)
+  * refinedBy: [Reliability Requirements](#reliability-requirements)
   * derivedFrom: [User Preferences](../BasicRequirements.md#user-req-001-notification-preferences)  
 
 ---
@@ -23,8 +23,8 @@ The system should implement a reliable publishing mechanism for notifications.
 
 
 #### Relations
-  * refine: NOTIF-ARCH-001 Reliable and Fault Tolerant Architecture
-  * derivedFrom: ../BasicRequirements.md#USER-REQ-002 Multi-channel Notifications
+  * refine: [NOTIF-ARCH-001 Reliable and Fault Tolerant Architecture](#notif-arch-001-reliable-and-fault-tolerant-architecture)
+  * derivedFrom: [USER-REQ-002 Multi-channel Notifications](../BasicRequirements.md#user-req-002-multi-channel-notifications)
 
 ---
 
@@ -34,7 +34,7 @@ The system should implement efficient delivery of notifications to recipients.
 
 
 #### Relations
-  * refine: NOTIF-ARCH-001 Reliable and Fault Tolerant Architecture
+  * refine: [NOTIF-ARCH-001 Reliable and Fault Tolerant Architecture](#notif-arch-001-reliable-and-fault-tolerant-architecture)
   * derivedFrom: [User Notification Grouping](../BasicRequirements.md#user-req-003-notification-grouping)
 
 ---
@@ -44,8 +44,8 @@ The system should implement efficient delivery of notifications to recipients.
 The system should store notifications for retrieval and audit purposes.
 
 #### Relations
-  * trace: NOTIF-IMPL-001 Notifications Publishing
-  * refine: NOTIF-IMPL-002 Notifications Delivery
+  * trace: [NOTIF-IMPL-001 Notifications Publishing](#notif-impl-001-notifications-publishing)
+  * refine: [NOTIF-IMPL-002 Notifications Delivery](#notif-impl-002-notifications-delivery)
   * derivedFrom: [Notification Interaction](../BasicRequirements.md#user-ux-001-notification-interaction)
 
 ---
@@ -56,4 +56,4 @@ The notification system must meet specific reliability requirements.
 
 
 #### Relations
-  * refine: NOTIF-ARCH-001 Reliable and Fault Tolerant Architecture
+  * refine: [NOTIF-ARCH-001 Reliable and Fault Tolerant Architecture](#notif-arch-001-reliable-and-fault-tolerant-architecture)

--- a/tests/test-invalid-relations/specifications/SystemRequirements/Requirements.md
+++ b/tests/test-invalid-relations/specifications/SystemRequirements/Requirements.md
@@ -153,3 +153,82 @@ This requirement has duplicate subsection.
   * containedBy: [../UserRequirements.md/Valid User Requirement](../UserRequirements.md#valid-user-requirement)
 
 ---
+
+### Verification with Missing SatisfiedBy Target
+
+This verification has a satisfiedBy relation pointing to a non-existing file.
+
+#### Metadata
+  * type: verification
+
+#### Relations
+  * verify: [Valid Requirement](#valid-requirement)
+  * satisfiedBy: [non-existing-test-script.sh](non-existing-test-script.sh)
+
+---
+
+### Requirement with Missing VerifiedBy Target
+
+This requirement has a verifiedBy relation pointing to a non-existing verification element.
+
+#### Relations
+  * containedBy: [../UserRequirements.md/Valid User Requirement](../UserRequirements.md#valid-user-requirement)
+  * verifiedBy: [NonExistentVerification.md#missing-verification](NonExistentVerification.md#missing-verification)
+
+---
+
+### Valid Requirement with Correct SatisfiedBy
+
+This requirement correctly uses satisfiedBy pointing to an existing implementation file.
+
+#### Relations
+  * containedBy: [../UserRequirements.md/Valid User Requirement](../UserRequirements.md#valid-user-requirement)
+  * satisfiedBy: [ValidImplementation.txt](ValidImplementation.txt)
+
+---
+
+### Valid Verification with Correct SatisfiedBy
+
+This verification correctly uses satisfiedBy pointing to an existing test script.
+
+#### Metadata
+  * type: verification
+
+#### Relations
+  * verify: [Valid Requirement](#valid-requirement)
+  * satisfiedBy: [test.sh](test.sh)
+
+---
+
+### Requirement SatisfiedBy Requirement Invalid
+
+This requirement incorrectly uses satisfiedBy pointing to another requirement (should fail).
+
+#### Relations
+  * containedBy: [../UserRequirements.md/Valid User Requirement](../UserRequirements.md#valid-user-requirement)
+  * satisfiedBy: [Valid Requirement](#valid-requirement)
+
+---
+
+### Verification SatisfiedBy Verification Invalid
+
+This verification incorrectly uses satisfiedBy pointing to another verification (should fail).
+
+#### Metadata
+  * type: verification
+
+#### Relations
+  * verify: [Valid Requirement](#valid-requirement)
+  * satisfiedBy: [Valid Verification with Correct SatisfiedBy](#valid-verification-with-correct-satisfiedby)
+
+---
+
+### Requirement with Missing SatisfiedBy File
+
+This requirement has a satisfiedBy relation pointing to a non-existing file.
+
+#### Relations
+  * containedBy: [../UserRequirements.md/Valid User Requirement](../UserRequirements.md#valid-user-requirement)
+  * satisfiedBy: [non-existing-implementation.py](non-existing-implementation.py)
+
+---

--- a/tests/test-invalid-relations/specifications/SystemRequirements/test.sh
+++ b/tests/test-invalid-relations/specifications/SystemRequirements/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Test script for verification satisfiedBy relation
+echo "This is a test script that implements the verification"


### PR DESCRIPTION
- Add validation for InternalPath file existence in satisfiedBy relations
- Remove broken logic that skipped non-markdown identifier validation
- Update specifications to clarify three identifier types and validation rules
- Fix broken relation identifiers in test-fragment-relations test data
- Add comprehensive test cases for satisfiedBy relation validation
- All 17 e2e tests now pass successfully

Fixes validation gaps where:
- Requirements with satisfiedBy pointing to missing files were not detected
- Verifications with satisfiedBy pointing to missing test scripts were not detected
- Non-markdown identifiers were incorrectly excluded from validation